### PR TITLE
Case-insensitive address queries

### DIFF
--- a/h5ai-nginx.conf
+++ b/h5ai-nginx.conf
@@ -91,11 +91,6 @@ server {
 		}
 	}
 
-		# Only allow contract level folders to avoid loading thousands of folders.
-	location "contracts\/(full_match|partial_match)\/\d+\/0x([A-Fa-f0-9]{40})"  {
-		try_files $uri $uri/ = 404;
-	}
-
 	# Only allow contract level folders to avoid loading thousands of folders.
 	location ~ "contracts\/(full_match|partial_match)\/\d+\/0x([A-Fa-f0-9]{40})"  {
 		index /_h5ai/public/formatAddress.php;


### PR DESCRIPTION
See https://github.com/ethereum/sourcify/issues/983

* removing a useless setting in h5ai config
* now formatting the address redirects to the `location /` that runs `try_files` successfuly