### PR TITLE
Make URL of sourcify server configurable

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,13 +7,7 @@
 /etc/init.d/php7.4-fpm start
 
 # Patch index.html to insert config parameter in the global window object
-CONFIG_STRING='\
-    <script> \
-      window.configs = { \
-        "SERVER_URL":"'"${SERVER_URL}"'", \
-      } \
-    </script>'
-sed -i "s@<script></script>@${CONFIG_STRING}@" /redirects/index.html
+sed -i "s@<script></script>@<script>window.configs={SERVER_URL:\"${SERVER_URL}\"}</script>@" /redirects/index.html
 
 # Start nginx
 nginx -g "daemon off;"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,5 +6,14 @@
 # Start php fpm
 /etc/init.d/php7.4-fpm start
 
+# Patch index.html to insert config parameter in the global window object
+CONFIG_STRING='\
+    <script> \
+      window.configs = { \
+        "SERVER_URL":"'"${SERVER_URL}"'", \
+      } \
+    </script>'
+sed -i "s@<script></script>@${CONFIG_STRING}@" /redirects/index.html
+
 # Start nginx
 nginx -g "daemon off;"

--- a/select-contract-form/public/index.html
+++ b/select-contract-form/public/index.html
@@ -40,6 +40,12 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Sourcify Repository</title>
+    <script>
+      // CONFIGURATION_PLACEHOLDER
+      // This comment will be removed at build time. The Docker entrypoint will
+      // look for this empty script element and insert the definition of configuration
+      // parameter(s) passed via the global window object.
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/select-contract-form/src/App.js
+++ b/select-contract-form/src/App.js
@@ -21,8 +21,11 @@ function App() {
 
   useEffect(() => {
     const getSourcifyChains = async () => {
+      const serverUrl = window.configs?.SERVER_URL?.length > 0
+          ? window.configs.SERVER_URL
+          : "https://sourcify.dev/server"
       const chainsArray = await (
-        await fetch(`https://sourcify.dev/server/chains`)
+        await fetch(`${serverUrl}/chains`)
       ).json();
       return chainsArray;
     };


### PR DESCRIPTION
These changes allow to configure the URL of the Sourcify server (which is contacted by the `select-contract-form` to get the supported chains) via a runtime environment variable:
- the URL of the server can be defined with the `$SERVER_URL` environment variable
- the Docker `entrypoint.sh` is used to insert a piece of script in the `index.html` of the select form. This script uses the value of `$SERVER_URL` to set a custom variable in the global `window` object
- the React code can access that value inside the `window` object
- the URL will be set to that value, if the `$SERVER_URL` environment variable was defined, and to `https://sourcify.dev/server` otherwise.
