### PR TITLE
Replace static file access with sourcify server api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,11 +32,6 @@ RUN apt update && \
 # Fix data location
 COPY class-setup.php /h5ai/_h5ai/private/php/core/class-setup.php
 
-# Create nginx configuration
-COPY h5ai-nginx.conf /etc/nginx/conf.d/h5ai-nginx.conf
-
-COPY nginx.conf /etc/nginx/nginx.conf
-
 # Copy entrypoint
 COPY entrypoint.sh /root/entrypoint.sh
 RUN chmod +x /root/entrypoint.sh
@@ -46,13 +41,17 @@ RUN apt install curl -y
 COPY options.json /h5ai/_h5ai/private/conf/options.json
 COPY types.json /h5ai/_h5ai/private/conf/types.json 
 
-CMD ["bash", "/root/entrypoint.sh"] 
-
-
 RUN apt install -y php-mbstring
 
 COPY formatAddress.php /h5ai/_h5ai/public/formatAddress.php
 COPY Kekkak.php /h5ai/_h5ai/public/Kekkak.php
+
+# Create nginx configuration
+COPY h5ai-nginx.conf.template /etc/nginx/conf.d/h5ai-nginx.conf.template
+
+COPY nginx.conf /etc/nginx/nginx.conf
+
+CMD ["bash", "/root/entrypoint.sh"] 
 
 LABEL org.opencontainers.image.source https://github.com/ethereum/sourcify
 LABEL org.opencontainers.image.licenses MIT

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ docker build -t h5ai-nginx .
 Run with
 
 ```
-docker run -d -p 10000:80 -v <local-path-to-repository>:/data h5ai-nginx
+docker run -d -e SOURCIFY_SERVER='<server-url>' -p 10000:80 -v <local-path-to-repository>:/data h5ai-nginx
 ```
 
 to access the repo at `http://localhost:10000`.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,5 +9,7 @@
 # Patch index.html to insert config parameter in the global window object
 sed -i "s@<script></script>@<script>window.configs={SERVER_URL:\"${SERVER_URL}\"}</script>@" /redirects/index.html
 
+envsubst '$SOURCIFY_SERVER' < /etc/nginx/conf.d/h5ai-nginx.conf.template > /etc/nginx/conf.d/h5ai-nginx.conf
+
 # Start nginx
 nginx -g "daemon off;"

--- a/h5ai-nginx.conf.template
+++ b/h5ai-nginx.conf.template
@@ -16,6 +16,13 @@ server {
 		try_files $uri @redirect;
 	}
 
+	# When specifically asking for a file redirect the request to the /server/repository/ API
+	location ~ ^/contracts/(full_match|partial_match)/(\d+)/([^/]+)/([^/]+)\.(\w+)$ {
+			rewrite ^/contracts/(full_match|partial_match)/(\d+)/([^/]+)/([^/]+)\.(\w+)$ /server/repository/contracts/$1/$2/$3/$4.$5 break;
+			# Proxy the transformed request to the target server.
+			proxy_pass $SOURCIFY_SERVER;
+	}
+
 	location @redirect {
 		return 301 /select-contract/;
 	}

--- a/h5ai-nginx.conf.template
+++ b/h5ai-nginx.conf.template
@@ -16,11 +16,10 @@ server {
 		try_files $uri @redirect;
 	}
 
-	# When specifically asking for a file redirect the request to the /server/repository/ API
-	location ~ ^/contracts/(full_match|partial_match)/(\d+)/([^/]+)/([^/]+)\.(\w+)$ {
-			rewrite ^/contracts/(full_match|partial_match)/(\d+)/([^/]+)/([^/]+)\.(\w+)$ /server/repository/contracts/$1/$2/$3/$4.$5 break;
-			# Proxy the transformed request to the target server.
-			proxy_pass $SOURCIFY_SERVER;
+	# When specifically asking for a $uri that ends with `.something` redirect the request to the /server/repository/ API
+	location ~ ^/contracts/(.*\.\w+)$ {
+		rewrite ^/contracts/(.*\.\w+)$ /server/repository/contracts/$1 break;
+		proxy_pass $SOURCIFY_SERVER;
 	}
 
 	location @redirect {


### PR DESCRIPTION
See https://github.com/ethereum/sourcify/issues/1330

- In order to pass environment variables to a nginx configuration we need to use a template and then transform it with [envsubst](https://www.baeldung.com/linux/envsubst-command). I highlighted the only change in `h5ai-nginx.conf` with a comment
- In the infra we will need to pass the $SOURCIFY_SERVER environment variable containing the host of the sourcify instance we want to redirect the request to

This is the script that I'm using to run the docker container:

```bash
docker build -t h5ai-nginx-1 . && docker run -it --rm -e SOURCIFY_SERVER='https://staging.sourcify.dev' -p 10000:80 -v /tmp/sourcify/repository:/data h5ai-nginx-1
```