### PR TITLE
Use checksummed address to perform contract lookup

### DIFF
--- a/select-contract-form/package.json
+++ b/select-contract-form/package.json
@@ -7,6 +7,7 @@
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
     "bootstrap": "^5.1.1",
+    "@ethersproject/address": "^5.7.0",
     "node-sass": "^4.14.1",
     "react": "^17.0.2",
     "react-bootstrap": "^2.0.0-rc.0",

--- a/select-contract-form/src/App.js
+++ b/select-contract-form/src/App.js
@@ -2,6 +2,7 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import { useEffect, useRef, useState } from "react";
 import { Alert, Button, Card, Form, Spinner } from "react-bootstrap";
 import "./App.scss";
+import { getAddress } from "@ethersproject/address";
 
 function App() {
   const [selectedMatch, setSelectedMatch] = useState("full_match");
@@ -48,7 +49,8 @@ function App() {
       return;
     }
 
-    const uri = generateRepoURI(address, chainId, selectedMatch);
+    const checksummedAddress = getAddress(address.toLowerCase());
+    const uri = generateRepoURI(checksummedAddress, chainId, selectedMatch);
     // Look ahead if contract exists.
     setIsLoading(true);
     fetch(uri, { redirect: "follow" })


### PR DESCRIPTION
The `select-contract-form` does not allow address lookup with non-checksummed addresses. This PR fixes this.

Related issue https://github.com/ethereum/sourcify/issues/1341.