### PR TITLE
Support to enable or disable the 'Open repo in Remix' link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM node:14.14-alpine
 RUN apk add --no-cache git python2 make g++
 RUN git clone https://github.com/sourcifyeth/h5ai.git
+
+ARG HIDE_OPEN_IN_REMIX
+COPY hide-open-in-remix.patch /hide-open-in-remix.patch 
+RUN if [ "$HIDE_OPEN_IN_REMIX" = "1" ]; then cd h5ai && git apply --verbose /hide-open-in-remix.patch; fi
+
 RUN cd h5ai && npm install && npm run build 
 RUN mv $(ls -1 /h5ai/build/*.zip) /h5ai/build/h5ai.zip
 RUN ls /h5ai/build/

--- a/hide-open-in-remix.patch
+++ b/hide-open-in-remix.patch
@@ -1,0 +1,32 @@
+Subject: [PATCH] suppress link to remix
+---
+Index: src/_h5ai/public/js/lib/view/view.js
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/src/_h5ai/public/js/lib/view/view.js b/src/_h5ai/public/js/lib/view/view.js
+--- a/src/_h5ai/public/js/lib/view/view.js	(revision 15173ca22fcd4e9b2c0d11bdacc509428dba1bcd)
++++ b/src/_h5ai/public/js/lib/view/view.js	(date 1699289694771)
+@@ -32,9 +32,6 @@
+                 </li>
+             </ul>
+             <div id="view-hint"></div>
+-            <div style="margin-top: 2rem; text-decoration: underline;">
+-                <a id="open_in_remix" href="#" target="_blank" rel="noopener noreferrer">Open repo in Remix</a>
+-            </div>
+         </div>`;
+ const itemTpl =
+         `<li class="item">
+@@ -49,11 +46,9 @@
+ const $view = dom(viewTpl);
+ const $items = $view.find('#items');
+ const $hint = $view.find('#view-hint');
+-const $remix_link = $view.find('#open_in_remix');
+ const $path = global.window.location.href.split('/');
+ const $address = $path[6];
+ const $chainId = $path[5];
+-$remix_link.attr('href', `https://remix.ethereum.org/?#activate=sourcify&call=sourcify//fetchAndSave//${$address}//${$chainId}`);
+
+
+ const cropSize = (size, min, max) => Math.min(max, Math.max(min, size));


### PR DESCRIPTION
Related to https://github.com/ethereum/sourcify/issues/1385, this PR adds support to enable (default) or disable the 'Open repo in Remix' link.

<img width="703" alt="image" src="https://github.com/sourcifyeth/h5ai-nginx/assets/4592980/251fee63-fec5-4056-a5b2-aaf146739168">

It does so by setting the Docker build argument `HIDE_OPEN_IN_REMIX`. When set to `1` it will hide the link. Otherwise it leaves it unchanged (default).

When `HIDE_OPEN_IN_REMIX` is set to `1`, a patch to remove the link is applied. The patch was originally created here https://github.com/hashgraph/hedera-sourcify/pull/69.
