### PR TITLE
Select first available chain instead of default `1`

### DIFF
--- a/select-contract-form/src/App.js
+++ b/select-contract-form/src/App.js
@@ -31,7 +31,10 @@ function App() {
       return chainsArray;
     };
     getSourcifyChains()
-      .then((chains) => setChains(chains))
+      .then((chains) => {
+        setChains(chains);
+        setChainId(chains[0].chainId);
+      })
       .catch((err) => alert(err));
   }, []);
 


### PR DESCRIPTION
The _Chain_ select in `select-contract-form` uses `1` as a default chain. This might be a problem when the available chains from the server does not contain that chain. For example, with the following set of available chains (note that Ethereum mainnet `1` is not present)

<img width="257" alt="image" src="https://github.com/sourcifyeth/h5ai-nginx/assets/4592980/333c3294-3007-4320-a9e2-3584eb832698">


if the user looks up for a contract without changing the _Chain_ selection, a wrong chain is used to perform the lookup (instead of _Ganache Localhost_ in this case)_[1]_

<img width="811" alt="image" src="https://github.com/sourcifyeth/h5ai-nginx/assets/4592980/6934ca48-74e9-4cbd-96b9-0641c937b907">

This PR correctly sets the first available chain in the `select-contract-form` after fetching chains from the server _[2]_.

---

[1] Original issue https://github.com/hashgraph/hedera-sourcify/issues/64
[2] Fix from https://github.com/hashgraph/hedera-sourcify/pull/69/files#diff-c6376e0a8c58d8b0b5e75ccab0a57e3e65277cea66ab7b26435eccbacc6818f9R52-R56
